### PR TITLE
Refactor coninuous logging default enabled plus unit tests in pyspark…

### DIFF
--- a/packages/@aws-cdk/aws-glue-alpha/lib/jobs/job.ts
+++ b/packages/@aws-cdk/aws-glue-alpha/lib/jobs/job.ts
@@ -499,23 +499,36 @@ export abstract class Job extends JobBase {
    * @param props The properties for continuous logging configuration
    * @returns String containing the args for the continuous logging command
    */
-  public setupContinuousLogging(role: iam.IRole, props: ContinuousLoggingProps) {
+  public setupContinuousLogging(role: iam.IRole, props: ContinuousLoggingProps | undefined) : any {
+
+    // If the developer has explicitly disabled continuous logging return no args
+    if (props && !props.enabled) {
+      return {};
+    }
+
+    // Else we turn on continuous logging by default. Determine what log group to use.
     const args: {[key: string]: string} = {
       '--enable-continuous-cloudwatch-log': 'true',
-      '--enable-continuous-log-filter': (props.quiet ?? true).toString(),
     };
 
-    if (props.logGroup) {
+    if (props?.quiet) {
+      args['--enable-continuous-log-filter'] = (props.quiet ?? true).toString();
+    };
+
+    // If the developer provided a log group, add its name to the args and update the role.
+    if (props?.logGroup) {
       args['--continuous-log-logGroup'] = props.logGroup.logGroupName;
       props.logGroup.grantWrite(role);
     }
 
-    if (props.logStreamPrefix) {
+    if (props?.logStreamPrefix) {
       args['--continuous-log-logStreamPrefix'] = props.logStreamPrefix;
     }
-    if (props.conversionPattern) {
+
+    if (props?.conversionPattern) {
       args['--continuous-log-conversionPattern'] = props.conversionPattern;
     }
+
     return args;
   }
 

--- a/packages/@aws-cdk/aws-glue-alpha/lib/jobs/pyspark-etl-job.ts
+++ b/packages/@aws-cdk/aws-glue-alpha/lib/jobs/pyspark-etl-job.ts
@@ -62,8 +62,6 @@ export class PySparkEtlJob extends Job {
   public readonly role: iam.IRole;
   public readonly grantPrincipal: iam.IPrincipal;
 
-  //private logGroup: LogGroup;
-
   /**
    * The Spark UI logs location if Spark UI monitoring and debugging is enabled.
    *
@@ -85,6 +83,8 @@ export class PySparkEtlJob extends Job {
       physicalName: props.jobName,
     });
 
+    this.jobName = props.jobName ?? '';
+
     // Set up role and permissions for principal
     this.role = props.role, {
       assumedBy: new iam.ServicePrincipal('glue.amazonaws.com'),
@@ -97,7 +97,7 @@ export class PySparkEtlJob extends Job {
     this.sparkUILoggingLocation = sparkUIArgs?.location;
 
     // Enable CloudWatch metrics and continuous logging by default as a best practice
-    const continuousLoggingArgs = props.continuousLogging?.enabled ? this.setupContinuousLogging(this.role, props.continuousLogging) : {};
+    const continuousLoggingArgs = this.setupContinuousLogging(this.role, props.continuousLogging);
     const profilingMetricsArgs = { '--enable-metrics': '' };
     const observabilityMetricsArgs = { '--enable-observability-metrics': 'true' };
 
@@ -132,7 +132,6 @@ export class PySparkEtlJob extends Job {
       numberOfWorkers: props.numberOfWorkers ? props.numberOfWorkers : 10,
       maxRetries: props.maxRetries,
       executionProperty: props.maxConcurrentRuns ? { maxConcurrentRuns: props.maxConcurrentRuns } : undefined,
-      //notificationProperty: props.notifyDelayAfter ? { notifyDelayAfter: props.notifyDelayAfter.toMinutes() } : undefined,
       timeout: props.timeout?.toMinutes(),
       connections: props.connections ? { connections: props.connections.map((connection) => connection.connectionName) } : undefined,
       securityConfiguration: props.securityConfiguration?.securityConfigurationName,

--- a/packages/@aws-cdk/aws-glue-alpha/lib/jobs/pyspark-flex-etl-job.ts
+++ b/packages/@aws-cdk/aws-glue-alpha/lib/jobs/pyspark-flex-etl-job.ts
@@ -104,7 +104,7 @@ export class PySparkFlexEtlJob extends Job {
     this.sparkUILoggingLocation = sparkUIArgs?.location;
 
     // Enable CloudWatch metrics and continuous logging by default as a best practice
-    const continuousLoggingArgs = props.continuousLogging?.enabled ? this.setupContinuousLogging(this.role, props.continuousLogging) : {};
+    const continuousLoggingArgs = this.setupContinuousLogging(this.role, props.continuousLogging);
     const profilingMetricsArgs = { '--enable-metrics': '' };
     const observabilityMetricsArgs = { '--enable-observability-metrics': 'true' };
 

--- a/packages/@aws-cdk/aws-glue-alpha/lib/jobs/pyspark-streaming-job.ts
+++ b/packages/@aws-cdk/aws-glue-alpha/lib/jobs/pyspark-streaming-job.ts
@@ -98,7 +98,7 @@ export class PySparkStreamingJob extends Job {
     this.sparkUILoggingLocation = sparkUIArgs?.location;
 
     // Enable CloudWatch metrics and continuous logging by default as a best practice
-    const continuousLoggingArgs = props.continuousLogging?.enabled ? this.setupContinuousLogging(this.role, props.continuousLogging) : {};
+    const continuousLoggingArgs = this.setupContinuousLogging(this.role, props.continuousLogging);
     const profilingMetricsArgs = { '--enable-metrics': '' };
     const observabilityMetricsArgs = { '--enable-observability-metrics': 'true' };
 

--- a/packages/@aws-cdk/aws-glue-alpha/lib/jobs/python-shell-job.ts
+++ b/packages/@aws-cdk/aws-glue-alpha/lib/jobs/python-shell-job.ts
@@ -59,12 +59,20 @@ export class PythonShellJob extends Job {
     };
     this.grantPrincipal = this.role;
 
+    // Enable CloudWatch metrics and continuous logging by default as a best practice
+    const continuousLoggingArgs = this.setupContinuousLogging(this.role, props.continuousLogging);
+    const profilingMetricsArgs = { '--enable-metrics': '' };
+    const observabilityMetricsArgs = { '--enable-observability-metrics': 'true' };
+
     // Gather executable arguments
     const executableArgs = this.executableArguments(props);
 
     // Combine command line arguments into a single line item
     const defaultArguments = {
       ...executableArgs,
+      ...continuousLoggingArgs,
+      ...profilingMetricsArgs,
+      ...observabilityMetricsArgs,
       ...this.checkNoReservedArgs(props.defaultArguments),
     };
 

--- a/packages/@aws-cdk/aws-glue-alpha/lib/jobs/ray-job.ts
+++ b/packages/@aws-cdk/aws-glue-alpha/lib/jobs/ray-job.ts
@@ -61,7 +61,7 @@ export class RayJob extends Job {
     this.grantPrincipal = this.role;
 
     // Enable CloudWatch metrics and continuous logging by default as a best practice
-    const continuousLoggingArgs = props.continuousLogging?.enabled ? this.setupContinuousLogging(this.role, props.continuousLogging) : {};
+    const continuousLoggingArgs = this.setupContinuousLogging(this.role, props.continuousLogging);
     const profilingMetricsArgs = { '--enable-metrics': '' };
     const observabilityMetricsArgs = { '--enable-observability-metrics': 'true' };
 

--- a/packages/@aws-cdk/aws-glue-alpha/lib/jobs/scala-spark-etl-job.ts
+++ b/packages/@aws-cdk/aws-glue-alpha/lib/jobs/scala-spark-etl-job.ts
@@ -95,7 +95,7 @@ export class ScalaSparkEtlJob extends Job {
     this.sparkUILoggingLocation = sparkUIArgs?.location;
 
     // Enable CloudWatch metrics and continuous logging by default as a best practice
-    const continuousLoggingArgs = props.continuousLogging?.enabled ? this.setupContinuousLogging(this.role, props.continuousLogging) : {};
+    const continuousLoggingArgs = this.setupContinuousLogging(this.role, props.continuousLogging);
     const profilingMetricsArgs = { '--enable-metrics': '' };
     const observabilityMetricsArgs = { '--enable-observability-metrics': 'true' };
 

--- a/packages/@aws-cdk/aws-glue-alpha/lib/jobs/scala-spark-flex-etl-job.ts
+++ b/packages/@aws-cdk/aws-glue-alpha/lib/jobs/scala-spark-flex-etl-job.ts
@@ -134,7 +134,7 @@ export class ScalaSparkFlexEtlJob extends Job {
     this.sparkUILoggingLocation = sparkUIArgs?.location;
 
     // Enable CloudWatch metrics and continuous logging by default as a best practice
-    const continuousLoggingArgs = props.continuousLogging?.enabled ? this.setupContinuousLogging(this.role, props.continuousLogging) : {};
+    const continuousLoggingArgs = this.setupContinuousLogging(this.role, props.continuousLogging);
     const profilingMetricsArgs = { '--enable-metrics': '' };
     const observabilityMetricsArgs = { '--enable-observability-metrics': 'true' };
 

--- a/packages/@aws-cdk/aws-glue-alpha/lib/jobs/scala-spark-streaming-job.ts
+++ b/packages/@aws-cdk/aws-glue-alpha/lib/jobs/scala-spark-streaming-job.ts
@@ -94,7 +94,7 @@ export class ScalaSparkStreamingJob extends Job {
     this.sparkUILoggingLocation = sparkUIArgs?.location;
 
     // Enable CloudWatch metrics and continuous logging by default as a best practice
-    const continuousLoggingArgs = props.continuousLogging?.enabled ? this.setupContinuousLogging(this.role, props.continuousLogging) : {};
+    const continuousLoggingArgs = this.setupContinuousLogging(this.role, props.continuousLogging);
     const profilingMetricsArgs = { '--enable-metrics': '' };
     const observabilityMetricsArgs = { '--enable-observability-metrics': 'true' };
 

--- a/packages/@aws-cdk/aws-glue-alpha/test/code.test.ts
+++ b/packages/@aws-cdk/aws-glue-alpha/test/code.test.ts
@@ -1,5 +1,5 @@
 import * as path from 'path';
-import { Template } from 'aws-cdk-lib/assertions';
+import { Template, Match } from 'aws-cdk-lib/assertions';
 import * as s3 from 'aws-cdk-lib/aws-s3';
 import * as cdk from 'aws-cdk-lib';
 import * as cxapi from 'aws-cdk-lib/cx-api';
@@ -23,7 +23,7 @@ describe('Code', () => {
       bucket = s3.Bucket.fromBucketName(stack, 'Bucket', 'bucketname');
       script = glue.Code.fromBucket(bucket, key);
 
-      new glue.PythonShellJob(stack, 'Job1', {
+      const job = new glue.PythonShellJob(stack, 'Job1', {
         script,
         role: new Role(stack, 'Role', {
           assumedBy: new ServicePrincipal('glue.amazonaws.com'),
@@ -78,7 +78,7 @@ describe('Code', () => {
         },
         Roles: [
           {
-            Ref: 'Job1ServiceRole7AF34CCA',
+            Ref: Match.stringLikeRegexp('Role'),
           },
         ],
       });
@@ -193,7 +193,7 @@ describe('Code', () => {
         },
         Roles: [
           {
-            Ref: 'Job1ServiceRole7AF34CCA',
+            Ref: Match.stringLikeRegexp('Role'),
           },
         ],
       });
@@ -207,13 +207,13 @@ describe('Code', () => {
     test('used in more than 1 job in the same stack should be reused', () => {
       new glue.PythonShellJob(stack, 'Job1', {
         script,
-        role: new Role(stack, 'Role', {
+        role: new Role(stack, 'Role1', {
           assumedBy: new ServicePrincipal('glue.amazonaws.com'),
         }),
       });
       new glue.PythonShellJob(stack, 'Job2', {
         script,
-        role: new Role(stack, 'Role', {
+        role: new Role(stack, 'Role2', {
           assumedBy: new ServicePrincipal('glue.amazonaws.com'),
         }),
       });
@@ -264,7 +264,7 @@ describe('Code', () => {
         },
         Role: {
           'Fn::GetAtt': [
-            'Job1ServiceRole7AF34CCA',
+            Match.stringLikeRegexp('Role'),
             'Arn',
           ],
         },
@@ -275,7 +275,7 @@ describe('Code', () => {
         },
         Role: {
           'Fn::GetAtt': [
-            'Job2ServiceRole5D2B98FE',
+            Match.stringLikeRegexp('Role'),
             'Arn',
           ],
         },
@@ -285,7 +285,7 @@ describe('Code', () => {
     test('throws if trying to rebind in another stack', () => {
       new glue.PythonShellJob(stack, 'Job1', {
         script,
-        role: new Role(stack, 'Role', {
+        role: new Role(stack, 'Role1', {
           assumedBy: new ServicePrincipal('glue.amazonaws.com'),
         }),
       });
@@ -293,7 +293,7 @@ describe('Code', () => {
 
       expect(() => new glue.PythonShellJob(differentStack, 'Job1', {
         script,
-        role: new Role(stack, 'Role', {
+        role: new Role(stack, 'Role2', {
           assumedBy: new ServicePrincipal('glue.amazonaws.com'),
         }),
       })).toThrow(/associated with another stack/);

--- a/packages/@aws-cdk/aws-glue-alpha/test/integ.job-pyspark-etl.js.snapshot/aws-glue-job-pyspark-etl.assets.json
+++ b/packages/@aws-cdk/aws-glue-alpha/test/integ.job-pyspark-etl.js.snapshot/aws-glue-job-pyspark-etl.assets.json
@@ -14,7 +14,7 @@
         }
       }
     },
-    "b69265e3929a8fd6ea69db3797d7382df3816ef168f310b15d41ba6fe9f00e81": {
+    "4799b81562fc3fe83d1f986c3c439f80d36cbfc9421a3e8558060ffaf8616aa0": {
       "source": {
         "path": "aws-glue-job-pyspark-etl.template.json",
         "packaging": "file"
@@ -22,7 +22,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "b69265e3929a8fd6ea69db3797d7382df3816ef168f310b15d41ba6fe9f00e81.json",
+          "objectKey": "4799b81562fc3fe83d1f986c3c439f80d36cbfc9421a3e8558060ffaf8616aa0.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/packages/@aws-cdk/aws-glue-alpha/test/integ.job-pyspark-etl.js.snapshot/aws-glue-job-pyspark-etl.template.json
+++ b/packages/@aws-cdk/aws-glue-alpha/test/integ.job-pyspark-etl.js.snapshot/aws-glue-job-pyspark-etl.template.json
@@ -109,6 +109,7 @@
     },
     "DefaultArguments": {
      "--job-language": "python",
+     "--enable-continuous-cloudwatch-log": "true",
      "--enable-metrics": "",
      "--enable-observability-metrics": "true"
     },
@@ -144,6 +145,7 @@
     },
     "DefaultArguments": {
      "--job-language": "python",
+     "--enable-continuous-cloudwatch-log": "true",
      "--enable-metrics": "",
      "--enable-observability-metrics": "true",
      "arg1": "value1",

--- a/packages/@aws-cdk/aws-glue-alpha/test/integ.job-pyspark-etl.js.snapshot/manifest.json
+++ b/packages/@aws-cdk/aws-glue-alpha/test/integ.job-pyspark-etl.js.snapshot/manifest.json
@@ -18,7 +18,7 @@
         "validateOnSynth": false,
         "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-deploy-role-${AWS::AccountId}-${AWS::Region}",
         "cloudFormationExecutionRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-cfn-exec-role-${AWS::AccountId}-${AWS::Region}",
-        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/b69265e3929a8fd6ea69db3797d7382df3816ef168f310b15d41ba6fe9f00e81.json",
+        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/4799b81562fc3fe83d1f986c3c439f80d36cbfc9421a3e8558060ffaf8616aa0.json",
         "requiresBootstrapStackVersion": 6,
         "bootstrapStackVersionSsmParameter": "/cdk-bootstrap/hnb659fds/version",
         "additionalDependencies": [

--- a/packages/@aws-cdk/aws-glue-alpha/test/integ.job-pyspark-etl.js.snapshot/tree.json
+++ b/packages/@aws-cdk/aws-glue-alpha/test/integ.job-pyspark-etl.js.snapshot/tree.json
@@ -194,6 +194,7 @@
                     },
                     "defaultArguments": {
                       "--job-language": "python",
+                      "--enable-continuous-cloudwatch-log": "true",
                       "--enable-metrics": "",
                       "--enable-observability-metrics": "true"
                     },
@@ -247,6 +248,7 @@
                     },
                     "defaultArguments": {
                       "--job-language": "python",
+                      "--enable-continuous-cloudwatch-log": "true",
                       "--enable-metrics": "",
                       "--enable-observability-metrics": "true",
                       "arg1": "value1",

--- a/packages/@aws-cdk/aws-glue-alpha/test/integ.job-scalaspark-etl.js.snapshot/aws-glue-job-scalaspark-etl.assets.json
+++ b/packages/@aws-cdk/aws-glue-alpha/test/integ.job-scalaspark-etl.js.snapshot/aws-glue-job-scalaspark-etl.assets.json
@@ -14,7 +14,7 @@
         }
       }
     },
-    "5d07dbbcf92246e5c8cb128178cd6f66a5abc0d138f9470a93062a2449c80a14": {
+    "95d6306a689415ff849d8061f263d71b4ee7eab3bb724e06f1356c346a111258": {
       "source": {
         "path": "aws-glue-job-scalaspark-etl.template.json",
         "packaging": "file"
@@ -22,7 +22,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "5d07dbbcf92246e5c8cb128178cd6f66a5abc0d138f9470a93062a2449c80a14.json",
+          "objectKey": "95d6306a689415ff849d8061f263d71b4ee7eab3bb724e06f1356c346a111258.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/packages/@aws-cdk/aws-glue-alpha/test/integ.job-scalaspark-etl.js.snapshot/aws-glue-job-scalaspark-etl.template.json
+++ b/packages/@aws-cdk/aws-glue-alpha/test/integ.job-scalaspark-etl.js.snapshot/aws-glue-job-scalaspark-etl.template.json
@@ -109,6 +109,7 @@
     "DefaultArguments": {
      "--job-language": "scala",
      "--class": "com.example.HelloWorld",
+     "--enable-continuous-cloudwatch-log": "true",
      "--enable-metrics": "",
      "--enable-observability-metrics": "true"
     },
@@ -144,6 +145,7 @@
     "DefaultArguments": {
      "--job-language": "scala",
      "--class": "com.example.HelloWorld",
+     "--enable-continuous-cloudwatch-log": "true",
      "--enable-metrics": "",
      "--enable-observability-metrics": "true",
      "arg1": "value1",

--- a/packages/@aws-cdk/aws-glue-alpha/test/integ.job-scalaspark-etl.js.snapshot/manifest.json
+++ b/packages/@aws-cdk/aws-glue-alpha/test/integ.job-scalaspark-etl.js.snapshot/manifest.json
@@ -18,7 +18,7 @@
         "validateOnSynth": false,
         "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-deploy-role-${AWS::AccountId}-${AWS::Region}",
         "cloudFormationExecutionRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-cfn-exec-role-${AWS::AccountId}-${AWS::Region}",
-        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/5d07dbbcf92246e5c8cb128178cd6f66a5abc0d138f9470a93062a2449c80a14.json",
+        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/95d6306a689415ff849d8061f263d71b4ee7eab3bb724e06f1356c346a111258.json",
         "requiresBootstrapStackVersion": 6,
         "bootstrapStackVersionSsmParameter": "/cdk-bootstrap/hnb659fds/version",
         "additionalDependencies": [

--- a/packages/@aws-cdk/aws-glue-alpha/test/integ.job-scalaspark-etl.js.snapshot/tree.json
+++ b/packages/@aws-cdk/aws-glue-alpha/test/integ.job-scalaspark-etl.js.snapshot/tree.json
@@ -194,6 +194,7 @@
                     "defaultArguments": {
                       "--job-language": "scala",
                       "--class": "com.example.HelloWorld",
+                      "--enable-continuous-cloudwatch-log": "true",
                       "--enable-metrics": "",
                       "--enable-observability-metrics": "true"
                     },
@@ -247,6 +248,7 @@
                     "defaultArguments": {
                       "--job-language": "scala",
                       "--class": "com.example.HelloWorld",
+                      "--enable-continuous-cloudwatch-log": "true",
                       "--enable-metrics": "",
                       "--enable-observability-metrics": "true",
                       "arg1": "value1",


### PR DESCRIPTION
…-etl-job and fixed other unit tests

### Issue # (if applicable)

N/A

### Reason for this change

Continuous logging was not enabled by default; thought we needed to create a new log group if the developer didn't provide one. Per Glue documentation, Glue will create/use its own log group, so we only need to 1/ enable continuous logging, and 2/ override the log group if the developer provides one. 

### Description of changes

Addressed log group complexity above, plus refactored the continuous logging method in the parent Job class to alleviate conditional complexity in the implementation classes.

### Description of how you validated changes

Added unit tests to cover aforementioned log group complexity, validated all unit and integration tests.

### Checklist
- [ X ] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
