### PR TITLE
WorkerType and numberofWorkers defaults are enforced when not set

### DIFF
--- a/packages/@aws-cdk/aws-glue-alpha/lib/jobs/ray-job.ts
+++ b/packages/@aws-cdk/aws-glue-alpha/lib/jobs/ray-job.ts
@@ -75,10 +75,6 @@ export class RayJob extends Job {
       throw new Error('Ray jobs only support Z.2X worker type');
     };
 
-    if ((!props.workerType && props.numberOfWorkers !== undefined) || (props.workerType && props.numberOfWorkers === undefined)) {
-      throw new Error('Both workerType and numberOFWorkers must be set');
-    }
-
     const jobResource = new CfnJob(this, 'Resource', {
       name: props.jobName,
       description: props.description,

--- a/packages/@aws-cdk/aws-glue-alpha/test/ray-job.test.ts
+++ b/packages/@aws-cdk/aws-glue-alpha/test/ray-job.test.ts
@@ -62,12 +62,6 @@ describe('Job', () => {
         }),
       });
     });
-
-    test('Default numberOfWorkers should be 3', () => {
-      Template.fromStack(stack).hasResourceProperties('AWS::Glue::Job', {
-        NumberOfWorkers: 3,
-      });
-    });
   });
 
   describe('Create new Ray Job with log override parameters', () => {
@@ -263,26 +257,6 @@ describe('Job', () => {
           workerType: glue.WorkerType.G_025X,
         });
       }).toThrow(new Error('Ray jobs only support Z.2X worker type'));
-    });
-
-    test('Create Ray Job overriding only workerType to cause an Error', () => {
-      expect(() => {
-        job = new glue.RayJob(stack, 'RayJob', {
-          role,
-          script,
-          workerType: glue.WorkerType.Z_2X,
-        });
-      }).toThrow(new Error('Both workerType and numberOFWorkers must be set'));
-    });
-
-    test('Create Ray Job overriding only numberOfWorkers to cause an Error', () => {
-      expect(() => {
-        job = new glue.RayJob(stack, 'RayJob', {
-          role,
-          script,
-          numberOfWorkers: 5,
-        });
-      }).toThrow(new Error('Both workerType and numberOFWorkers must be set'));
     });
   });
 });


### PR DESCRIPTION
### Issue # (if applicable)

Closes #<issue number here>.

### Reason for this change

WorkerType and numberofWorkers defaults are enforced when not set. Remove the additional validation.


### Description of changes

Fix integration tests for ray job type.


### Description of how you validated changes
Ran unit and integration tests.

<!--Have you added any unit tests and/or integration tests?-->

### Checklist
- [ ] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
